### PR TITLE
docs: bring docs changes from main repo

### DIFF
--- a/docs/other-topics/other-data-types.mdx
+++ b/docs/other-topics/other-data-types.mdx
@@ -426,6 +426,25 @@ Timeline.create({ range: [null, new Date(Date.UTC(2016, 0, 1))] });
 Timeline.create({ range: [-Infinity, new Date(Date.UTC(2016, 0, 1))] });
 ```
 
+#### In TypeScript
+
+Use the `Range` type provided by Sequelize to properly type your range:
+
+```typescript
+import { Model, InferAttributes, Range } from '@sequelize/core';
+
+class User extends Model<InferAttributes<User>> {
+  declare myDateRange: Range<Date>;
+}
+
+User.init({
+  myDateRange: {
+    type: DataTypes.RANGE(DataTypes.DATE),
+    allowNull: false,
+  }
+});
+```
+
 ### Network Addresses
 
 <DialectTableFilter>

--- a/docs/other-topics/typescript.mdx
+++ b/docs/other-topics/typescript.mdx
@@ -102,9 +102,67 @@ import modelInitExample from '!!raw-loader!../../.sequelize/v7/test/types/typesc
   {modelInitExample}
 </CodeBlock>
 
+### The case of `Model.init`
+
+`Model.init` requires an attribute configuration for each attribute declared in typings.
+
+Some attributes don't actually need to be passed to `Model.init`, this is how you can make this static method aware of them:
+
+- Methods used to define associations (`Model.belongsTo`, `Model.hasMany`, etc…) already handle
+  the configuration of the necessary foreign keys attributes. It is not necessary to configure
+  these foreign keys using `Model.init`.
+  Use the `ForeignKey<>` branded type to make `Model.init` aware of the fact that it isn't necessary to configure the foreign key:
+
+  ```typescript
+  import { Model, InferAttributes, InferCreationAttributes, DataTypes, ForeignKey } from 'sequelize';
+
+  class Project extends Model<InferAttributes<Project>, InferCreationAttributes<Project>> {
+    id: number;
+    userId: ForeignKey<number>;
+  }
+
+  // this configures the `userId` attribute.
+  Project.belongsTo(User);
+
+  // therefore, `userId` doesn't need to be specified here.
+  Project.init({
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+  }, { sequelize });
+  ```
+
+- Timestamp attributes managed by Sequelize (by default, `createdAt`, `updatedAt`, and `deletedAt`) don't need to be configured using `Model.init`,
+  unfortunately `Model.init` has no way of knowing this. We recommend you use the minimum necessary configuration to silence this error:
+
+  ```typescript
+  import { Model, InferAttributes, InferCreationAttributes, DataTypes } from 'sequelize';
+
+  class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+    id: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }
+
+  User.init({
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    // technically, `createdAt` & `updatedAt` are added by Sequelize and don't need to be configured in Model.init
+    // but the typings of Model.init do not know this. Add the following to mute the typing error:
+    createdAt: DataTypes.DATE,
+    updatedAt: DataTypes.DATE,
+  }, { sequelize });
+  ```
+
 ### Usage without strict types for attributes
 
-The typings for Sequelize v5 allowed you to define models without specifying types for the attributes. This is still possible for backwards compatibility and for cases where you feel strict typing for attributes isn't worth it.
+The typings for Sequelize v5 allowed you to define models without specifying types for the attributes. 
+This is still possible for backwards compatibility and for cases where you feel strict typing for attributes isn't worth it.
 
 import modelInitNoAttributesExample from '!!raw-loader!../../.sequelize/v7/test/types/typescriptDocs/ModelInitNoAttributes.ts';
 
@@ -114,20 +172,13 @@ import modelInitNoAttributesExample from '!!raw-loader!../../.sequelize/v7/test/
 
 ## Usage of `Sequelize#define`
 
-In Sequelize versions before v5, the default way of defining a model involved using [`Sequelize#define`](pathname:///api/v7/classes/Sequelize.html#define). It's still possible to define models with that, and you can also add typings to these models using interfaces.
+In Sequelize versions before v5, the default way of defining a model involved using [`Sequelize#define`](pathname:///api/v7/classes/Sequelize.html#define). 
+It's still possible to define models with that, and you can also add typings to these models using interfaces.
 
 import defineExample from '!!raw-loader!../../.sequelize/v7/test/types/typescriptDocs/Define.ts';
 
 <CodeBlock className="language-typescript">
   {defineExample}
-</CodeBlock>
-
-If you're comfortable with somewhat less strict typing for the attributes on a model, you can save some code by defining the Instance to just extend [`Model`](pathname:///api/v7/classes/Model.html) without any attributes in the generic types.
-
-import defineNoAttributesExample from '!!raw-loader!../../.sequelize/v7/test/types/typescriptDocs/DefineNoAttributes.ts';
-
-<CodeBlock className="language-typescript">
-  {defineNoAttributesExample}
 </CodeBlock>
 
 ## Utility Types


### PR DESCRIPTION
This PR brings the different documentation changes that have been merged in the main repo since the migration.

It:

- Documents the new `Range` type
- Documents the new `ForeignKey` type
- Removes the "untyped" version of `sequelize.define` from the typescript documentation, because the new way of typing models is just as easy as not typing, so there isn't a good reason to not type models anymore.