### PR TITLE
Swap Github Pages based deployment with direct netlify deployments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 # curl -XPOST -u "username:access-token" -H "Accept: application/vnd.github.v3+json" -H "Content-Type: application/json" https://api.github.com/repos/sequelize/website/dispatches --data '{"event_type":"Build website"}'
 
 name: Website Deployment
-on: 
+on:
   repository_dispatch:
   push:
     branches:
@@ -22,11 +22,11 @@ jobs:
       - run: yarn typecheck
       - run: yarn sync
       - run: yarn build
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Prepare Netlify dependencies
+        run: npm install netlify-cli -g
+      - name: Deploy to Netlify
         if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: sequelize-site
+        run: netlify deploy --dir build --prod

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,4 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: sequelize-site
-        run: netlify deploy --dir build --prod
+        run: netlify deploy --dir build --prod --message '${{ github.event.commits[0].message }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Prepare Netlify dependencies
         run: npm install netlify-cli -g
       - name: Deploy to Netlify
-        if: ${{ github.ref == 'refs/heads/main' }}
+        # if: ${{ github.ref == 'refs/heads/main' }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: sequelize-site

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-      - redirects
+      - netlify-deployment
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - netlify-deployment
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,7 +24,7 @@ jobs:
       - name: Prepare Netlify dependencies
         run: npm install netlify-cli -g
       - name: Deploy to Netlify
-        # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: sequelize-site


### PR DESCRIPTION
Currently (before this PR), we were having the following CI/CD flow

1. A change is merged to main
2. The build on main syncs code/builds the docs/uploads to gh-pages
3. Netlify observes all changes to gh-pages and essentially just takes whatever is in the root dir and uploads it to the CDN

After this PR

1. A change is merged to main
2. The build on main syncs code/builds the docs/uploads the build directory straight to Netlify.

Since the preview doesn't seem to work properly, we could tweak in a way that it will create draft versions for any code change outside of the main branch. What do you think?

This is what you'll see in netlify
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/79163/161329753-1a1b27d7-04ad-4484-a871-490d1c81f5be.png">

This is how a build looks like https://github.com/sequelize/website/actions/runs/2079276392

PS: The reason why the draft doesn't work is very like because of the builds that I couldn't get to run on Netlify. 