### PR TITLE
docs(op): fix queries example for [Op.any]

### DIFF
--- a/docs/core-concepts/model-querying-basics.md
+++ b/docs/core-concepts/model-querying-basics.md
@@ -268,11 +268,11 @@ Post.findAll({
       [Op.iRegexp]: '^[h|a|t]',                // ~* '^[h|a|t]' (PG only)
       [Op.notIRegexp]: '^[h|a|t]',             // !~* '^[h|a|t]' (PG only)
 
-      [Op.any]: [2, 3],                        // ANY ARRAY[2, 3]::INTEGER (PG only)
+      [Op.any]: [2, 3],                        // ANY(ARRAY[2, 3]::INTEGER[]) (PG only)
       [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // match text search for strings 'fat' and 'rat' (PG only)
 
       // In Postgres, Op.like/Op.iLike/Op.notLike can be combined to Op.any:
-      [Op.like]: { [Op.any]: ['cat', 'hat'] }  // LIKE ANY ARRAY['cat', 'hat']
+      [Op.like]: { [Op.any]: ['cat', 'hat'] }  // LIKE ANY(ARRAY['cat', 'hat'])
 
       // There are more postgres-only range operators, see below
     }

--- a/docs/core-concepts/model-querying-basics.md
+++ b/docs/core-concepts/model-querying-basics.md
@@ -268,11 +268,11 @@ Post.findAll({
       [Op.iRegexp]: '^[h|a|t]',                // ~* '^[h|a|t]' (PG only)
       [Op.notIRegexp]: '^[h|a|t]',             // !~* '^[h|a|t]' (PG only)
 
-      [Op.any]: [2, 3],                        // ANY(ARRAY[2, 3]::INTEGER[]) (PG only)
+      [Op.any]: [2, 3],                        // ANY (ARRAY[2, 3]::INTEGER[]) (PG only)
       [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // match text search for strings 'fat' and 'rat' (PG only)
 
       // In Postgres, Op.like/Op.iLike/Op.notLike can be combined to Op.any:
-      [Op.like]: { [Op.any]: ['cat', 'hat'] }  // LIKE ANY(ARRAY['cat', 'hat'])
+      [Op.like]: { [Op.any]: ['cat', 'hat'] }  // LIKE ANY (ARRAY['cat', 'hat'])
 
       // There are more postgres-only range operators, see below
     }

--- a/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
+++ b/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
@@ -264,11 +264,11 @@ Post.findAll({
       [Op.iRegexp]: '^[h|a|t]',                // ~* '^[h|a|t]' (PG only)
       [Op.notIRegexp]: '^[h|a|t]',             // !~* '^[h|a|t]' (PG only)
 
-      [Op.any]: [2, 3],                        // ANY ARRAY[2, 3]::INTEGER (PG only)
+      [Op.any]: [2, 3],                        // ANY(ARRAY[2, 3]::INTEGER[]) (PG only)
       [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // match text search for strings 'fat' and 'rat' (PG only)
 
       // In Postgres, Op.like/Op.iLike/Op.notLike can be combined to Op.any:
-      [Op.like]: { [Op.any]: ['cat', 'hat'] }  // LIKE ANY ARRAY['cat', 'hat']
+      [Op.like]: { [Op.any]: ['cat', 'hat'] }  // LIKE ANY(ARRAY['cat', 'hat'])
 
       // There are more postgres-only range operators, see below
     }

--- a/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
+++ b/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
@@ -264,11 +264,11 @@ Post.findAll({
       [Op.iRegexp]: '^[h|a|t]',                // ~* '^[h|a|t]' (PG only)
       [Op.notIRegexp]: '^[h|a|t]',             // !~* '^[h|a|t]' (PG only)
 
-      [Op.any]: [2, 3],                        // ANY(ARRAY[2, 3]::INTEGER[]) (PG only)
+      [Op.any]: [2, 3],                        // ANY (ARRAY[2, 3]::INTEGER[]) (PG only)
       [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // match text search for strings 'fat' and 'rat' (PG only)
 
       // In Postgres, Op.like/Op.iLike/Op.notLike can be combined to Op.any:
-      [Op.like]: { [Op.any]: ['cat', 'hat'] }  // LIKE ANY(ARRAY['cat', 'hat'])
+      [Op.like]: { [Op.any]: ['cat', 'hat'] }  // LIKE ANY (ARRAY['cat', 'hat'])
 
       // There are more postgres-only range operators, see below
     }


### PR DESCRIPTION
Copied from https://github.com/sequelize/sequelize/pull/14123

The [tests mentioned there](https://github.com/sequelize/sequelize/blob/1d6336f32320c66b004f6089c4bc39195904e355/test/unit/sql/where.test.js#L608-L623) has been superseded, but it seems that https://github.com/sequelize/sequelize/blob/main/test/unit/sql/where.test.ts#L508-L510 is the replacement