### PR TITLE
feat: drop support for node 12

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 
 Sequelize is a promise-based [Node.js](https://nodejs.org/en/about/) [ORM tool](https://en.wikipedia.org/wiki/Object-relational_mapping) for [Postgres](https://en.wikipedia.org/wiki/PostgreSQL), [MySQL](https://en.wikipedia.org/wiki/MySQL), [MariaDB](https://en.wikipedia.org/wiki/MariaDB), [SQLite](https://en.wikipedia.org/wiki/SQLite), [Microsoft SQL Server](https://en.wikipedia.org/wiki/Microsoft_SQL_Server), [Amazon Redshift](https://docs.aws.amazon.com/redshift/index.html) and [Snowflake’s Data Cloud](https://docs.snowflake.com/en/user-guide/intro-key-concepts.html). It features solid transaction support, relations, eager and lazy loading, read replication and more.
 
-Sequelize follows [Semantic Versioning](https://semver.org) and the [official Node.js LTS schedule](https://nodejs.org/en/about/releases/). Version 7 of Sequelize officially supports the Node.js versions `^12.22.0`, `^14.17,0`, `^16.0.0`. Other version might be working as well.
+Sequelize follows [Semantic Versioning](https://semver.org) and the [official Node.js LTS schedule](https://nodejs.org/en/about/releases/). Version 7 of Sequelize officially supports the Node.js versions `^14.17,0`, `^16.0.0`. Other version might be working as well.
 
 You are currently looking at the **Tutorials and Guides** for Sequelize. You might also be interested in the [API Reference](pathname:///api/v7).
 

--- a/docs/other-topics/upgrade-to-v7.md
+++ b/docs/other-topics/upgrade-to-v7.md
@@ -21,10 +21,10 @@ const sequelize = new Sequelize({ dialect: 'sqlite' });
 await sequelize.authenticate();
 ```
 
-### Support for Node 12 and up
+### Dropping support for Node 10 and 12
 
-Sequelize v7 will only support the versions of Node.js that are compatible with the ES module specification,
-namingly version 12 and upwards [#5](https://github.com/sequelize/meetings/issues/5).
+Sequelize v7 will only support the versions of Node.js that are still maintained when Sequelize 7 released,
+namingly version 14.17 and upwards [#5](https://github.com/sequelize/meetings/issues/5).
 
 ### TypeScript conversion
 


### PR DESCRIPTION
See https://github.com/sequelize/sequelize/pull/14339