### PR TITLE
docs: update sqlite's mode option docs

### DIFF
--- a/docs/other-topics/dialect-specific-things.md
+++ b/docs/other-topics/dialect-specific-things.md
@@ -158,18 +158,25 @@ You specify the storage file in the Sequelize constructor with the `storage` opt
 You can provide custom options to it using the `dialectOptions` in the Sequelize constructor:
 
 ```js
+import { Sequelize } from 'sequelize';
+import SQLite from 'sqlite3';
+
 const sequelize = new Sequelize('database', 'username', 'password', {
   dialect: 'sqlite',
   storage: 'path/to/database.sqlite', // or ':memory:'
   dialectOptions: {
     // Your sqlite3 options here
+    // for instance, this is how you can configure the database opening mode:
+    mode: SQLite.OPEN_READWRITE | SQLite.OPEN_CREATE | SQLite.OPEN_FULLMUTEX,
   },
 });
 ```
 
 The following fields may be passed to SQLite `dialectOptions`:
 
-- `readWriteMode`: Set the opening mode for the SQLite connection. Potential values are provided by the sqlite3 package, and can include sqlite3.OPEN_READONLY, sqlite3.OPEN_READWRITE, or sqlite3.OPEN_CREATE. See the [SQLite C interface documentation for more details]( https://www.sqlite.org/c3ref/open.html).
+- `mode`: Set the opening mode for the SQLite connection. Potential values are provided by the `sqlite3` package, 
+  and can include `SQLite.OPEN_READONLY`, `SQLite.OPEN_READWRITE`, or `SQLite.OPEN_CREATE`.  
+  See [sqlite3's API reference](https://github.com/TryGhost/node-sqlite3/wiki/API) and the [SQLite C interface documentation](https://www.sqlite.org/c3ref/open.html) for more details.
 
 ### Snowflake
 

--- a/versioned_docs/version-6.x.x/other-topics/dialect-specific-things.md
+++ b/versioned_docs/version-6.x.x/other-topics/dialect-specific-things.md
@@ -41,25 +41,33 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 
 ### SQLite
 
-The underlying connector library used by Sequelize for SQLite is the [sqlite3](https://www.npmjs.com/package/sqlite3) npm package (version 4.0.0 or above). Due to security vulnerabilities with sqlite3@^4 it is recommended to use the [@vscode/sqlite3](https://www.npmjs.com/package/@vscode/sqlite3) fork if updating to sqlite3@^5.0.3 is not possible.
+The underlying connector library used by Sequelize for SQLite is the [sqlite3](https://www.npmjs.com/package/sqlite3) npm package (version 4.0.0 or above).  
+Due to security vulnerabilities with sqlite3@^4 it is recommended to use the [@vscode/sqlite3](https://www.npmjs.com/package/@vscode/sqlite3) fork if updating to sqlite3@^5.0.3 is not possible.
 
 You specify the storage file in the Sequelize constructor with the `storage` option (use `:memory:` for an in-memory SQLite instance).
 
 You can provide custom options to it using the `dialectOptions` in the Sequelize constructor:
 
 ```js
+import { Sequelize } from 'sequelize';
+import SQLite from 'sqlite3';
+
 const sequelize = new Sequelize('database', 'username', 'password', {
   dialect: 'sqlite',
-  storage: 'path/to/database.sqlite' // or ':memory:'
+  storage: 'path/to/database.sqlite', // or ':memory:'
   dialectOptions: {
     // Your sqlite3 options here
-  }
+    // for instance, this is how you can configure the database opening mode:
+    mode: SQLite.OPEN_READWRITE | SQLite.OPEN_CREATE | SQLite.OPEN_FULLMUTEX,
+  },
 });
 ```
 
 The following fields may be passed to SQLite `dialectOptions`:
 
-- `readWriteMode`: Set the opening mode for the SQLite connection. Potential values are provided by the sqlite3 package, and can include sqlite3.OPEN_READONLY, sqlite3.OPEN_READWRITE, or sqlite3.OPEN_CREATE. See the [SQLite C interface documentation for more details]( https://www.sqlite.org/c3ref/open.html).
+- `mode`: Set the opening mode for the SQLite connection. Potential values are provided by the `sqlite3` package,
+  and can include `SQLite.OPEN_READONLY`, `SQLite.OPEN_READWRITE`, or `SQLite.OPEN_CREATE`.  
+  See [sqlite3's API reference](https://github.com/TryGhost/node-sqlite3/wiki/API) and the [SQLite C interface documentation](https://www.sqlite.org/c3ref/open.html) for more details.
 
 ### PostgreSQL
 


### PR DESCRIPTION
As [mentioned in this issue](https://github.com/sequelize/sequelize/issues/12329#issuecomment-1126053235), Sequelize's documentation mentions `dialectOptions.readWriteMode`, but that option is actually named [`dialectOptions.mode`](https://github.com/sequelize/sequelize/blob/main/src/dialects/sqlite/connection-manager.js#L64).

Relevant pages:
- https://sequelize.org/docs/v6/other-topics/dialect-specific-things/#sqlite
- https://sequelize.org/docs/v7/other-topics/dialect-specific-things/#sqlite