### PR TITLE
fix: update links to typescript snippets

### DIFF
--- a/docs/other-topics/typescript.mdx
+++ b/docs/other-topics/typescript.mdx
@@ -106,7 +106,7 @@ You only need to use `CreationOptional` & `NonAttribute` on class instance field
 Example of a minimal TypeScript project with strict type-checking for attributes:
 
 import CodeBlock from '@theme/CodeBlock';
-import modelInitExample from '!!raw-loader!@site/.sequelize/v7/test/types/typescriptDocs/ModelInit.ts';
+import modelInitExample from '!!raw-loader!@site/.sequelize/v7/test/types/typescript-docs/model-init.ts';
 
 <CodeBlock className="language-typescript">
   {modelInitExample}
@@ -174,7 +174,7 @@ Some attributes don't actually need to be passed to `Model.init`, this is how yo
 The typings for Sequelize v5 allowed you to define models without specifying types for the attributes. 
 This is still possible for backwards compatibility and for cases where you feel strict typing for attributes isn't worth it.
 
-import modelInitNoAttributesExample from '!!raw-loader!@site/.sequelize/v7/test/types/typescriptDocs/ModelInitNoAttributes.ts';
+import modelInitNoAttributesExample from '!!raw-loader!@site/.sequelize/v7/test/types/typescript-docs/model-init-no-attributes.ts';
 
 <CodeBlock className="language-typescript">
   {modelInitNoAttributesExample}
@@ -185,7 +185,7 @@ import modelInitNoAttributesExample from '!!raw-loader!@site/.sequelize/v7/test/
 In Sequelize versions before v5, the default way of defining a model involved using [`Sequelize#define`](pathname:///api/v7/classes/Sequelize.html#define). 
 It's still possible to define models with that, and you can also add typings to these models using interfaces.
 
-import defineExample from '!!raw-loader!@site/.sequelize/v7/test/types/typescriptDocs/Define.ts';
+import defineExample from '!!raw-loader!@site/.sequelize/v7/test/types/typescript-docs/define.ts';
 
 <CodeBlock className="language-typescript">
   {defineExample}


### PR DESCRIPTION
https://github.com/sequelize/sequelize/pull/14649 changed the casing of the files we reference in the documentation. This PR updates the relevant imports, so the website can build again.