### PR TITLE
docs(v6): Update transactions.md

### DIFF
--- a/versioned_docs/version-6.x.x/other-topics/transactions.md
+++ b/versioned_docs/version-6.x.x/other-topics/transactions.md
@@ -15,7 +15,7 @@ Sequelize supports two ways of using transactions:
 Let's start with an example:
 
 ```js
-// First, we start a transaction and save it into a variable
+// First, we start a transaction from your connection and save it into a variable
 const t = await sequelize.transaction();
 
 try {


### PR DESCRIPTION
Added note about the origin of the `sequelize` object.

The origin of the line is ambiguous and not are clear if I need to use my connection or a `Sequelize` dependency
```javascript
const t = await sequelize.transaction();
```

You can check here more people with this confusion [https://stackoverflow.com/questions/62273766/typeerror-sequelize-transaction-is-not-a-function](https://stackoverflow.com/questions/62273766/typeerror-sequelize-transaction-is-not-a-function)


