### PR TITLE
fix: escape | in releases table and update TS support

### DIFF
--- a/src/pages/releases.mdx
+++ b/src/pages/releases.mdx
@@ -10,11 +10,11 @@ This page regroups information related to which engines versions are supported b
 
 ## Releases
 
-| Sequelize                       | [Node.js][node-releases] | [Typescript][ts-releases] | Release Date | EOL        |
-|---------------------------------|--------------------------|---------------------------|--------------|------------|
-| [7 (alpha)][sequelize-core]     | ^14.17.0 || >= 16.0.0    | >= 4.4                    | ❓            | ❓          |
-| [6 (current)][sequelize-legacy] | >= 10                    | >= 3.9                    | 2020-06-24   | ❓          |
-| 5 (eol)                         | >=6                      | >= 3.1                    | 2019-03-13   | 2022-01-01 |
+| Sequelize                       |  [Node.js][node-releases]  | [Typescript][ts-releases] | Release Date | EOL        |
+|---------------------------------|----------------------------|---------------------------|--------------|------------|
+| [7 (alpha)][sequelize-core]     | ^14.17.0 \|\| >= 16.0.0    | >= 4.5                    | ❓           | ❓         |
+| [6 (current)][sequelize-legacy] | >= 10                      | >= 3.9                    | 2020-06-24   | ❓         |
+| 5 (eol)                         | >=6                        | >= 3.1                    | 2019-03-13   | 2022-01-01 |
 
 \* ❓ means the date has not been determined yet.
 


### PR DESCRIPTION
The release table was a bit broken because we were not escaping ||. We have also dropped TS 4.4 support for `main`