### PR TITLE
docs: update supported versions TypeScript for v6

### DIFF
--- a/src/pages/releases.mdx
+++ b/src/pages/releases.mdx
@@ -13,7 +13,7 @@ This page regroups information related to which engines versions are supported b
 | Sequelize                       |  [Node.js][node-releases]  | [Typescript][ts-releases] | Release Date | EOL        |
 |---------------------------------|----------------------------|---------------------------|--------------|------------|
 | [7 (alpha)][sequelize-core]     | ^14.17.0 \|\| >= 16.0.0    | >= 4.5                    | ❓           | ❓         |
-| [6 (current)][sequelize-legacy] | >= 10                      | >= 3.9                    | 2020-06-24   | ❓         |
+| [6 (current)][sequelize-legacy] | >= 10                      | >= 4.1                    | 2020-06-24   | ❓         |
 | 5 (eol)                         | >=6                        | >= 3.1                    | 2019-03-13   | 2022-01-01 |
 
 \* ❓ means the date has not been determined yet.


### PR DESCRIPTION
We only support TS 4.1 and above in v6 as per the TypeScript page, this brings both pages together https://github.com/sequelize/website/blob/2ec242d614cfba24237d279004a6279612b3245d/versioned_docs/version-6.x.x/other-topics/typescript.md?plain=1#L15