### PR TITLE
meta: auto-merge renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,16 @@
 {
   "extends": [
     "config:base",
-    ":semanticCommitType(build)",
-    ":maintainLockFilesWeekly"
+    ":maintainLockFilesWeekly",
+    ":semanticCommitScopeDisabled"
   ],
-  "ignorePaths": ["static/"]
+  "automergeStrategy": "squash",
+  "semanticCommitType": "meta",
+  "ignorePaths": ["static/"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
This aligns our renovate config with the main repo (with one difference: it auto-merges lockfile maintenance PRs).
