### PR TITLE
meta: fix commit type on renovate dependency PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base",
     ":maintainLockFilesWeekly",
+    ":semanticCommitTypeAll(meta)",
     ":semanticCommitScopeDisabled"
   ],
   "automergeStrategy": "squash",


### PR DESCRIPTION
We need both; one for the dependencies and one for the lockfile updates