### PR TITLE
fix: misleading hint in the 'Allowing/disallowing null values' section

### DIFF
--- a/versioned_docs/version-6.x.x/core-concepts/validations-and-constraints.md
+++ b/versioned_docs/version-6.x.x/core-concepts/validations-and-constraints.md
@@ -67,7 +67,7 @@ By default, `null` is an allowed value for every column of a model. This can be 
 } /* ... */
 ```
 
-Without `allowNull: false`, the call `User.create({})` would work.
+Without `allowNull: false`, the call `User.create({})` would work if and only if we set the `timestamps: false` in the model options.
 
 ### Note about `allowNull` implementation
 


### PR DESCRIPTION
In the `Allowing/disallowing null values` section, there's a misleading hint that says:
`Without allowNull: false, the call User.create({}) would work.`

This is actually wrong, because our model gets populated in the database with two other columns related to timestamps:
`created_at` and `updated_at` which are `NOT NULL` constraints by default, so this will only work if we set the `timestamps: false` option in our model option when we define our model.

