### PR TITLE
docs: improve example for datatypes TEXT

### DIFF
--- a/versioned_docs/version-6.x.x/core-concepts/model-basics.md
+++ b/versioned_docs/version-6.x.x/core-concepts/model-basics.md
@@ -334,7 +334,7 @@ DataTypes.STRING             // VARCHAR(255)
 DataTypes.STRING(1234)       // VARCHAR(1234)
 DataTypes.STRING.BINARY      // VARCHAR BINARY
 DataTypes.TEXT               // TEXT
-DataTypes.TEXT('tiny')       // TINYTEXT
+DataTypes.TEXT('tiny')       // tiny for TINYTEXT, medium for MEDIUMTEXT and long for LONGTEXT
 DataTypes.CITEXT             // CITEXT          PostgreSQL and SQLite only.
 DataTypes.TSVECTOR           // TSVECTOR        PostgreSQL only.
 ```


### PR DESCRIPTION
Improve the example datatypes TEXT, makes the documentation beginner-friendly as much as possible.