### PR TITLE
Fix bug when Project.find*({ include: User })

### DIFF
--- a/versioned_docs/version-6.x.x/other-topics/typescript.md
+++ b/versioned_docs/version-6.x.x/other-topics/typescript.md
@@ -298,6 +298,7 @@ User.hasMany(Project, {
   foreignKey: 'ownerId',
   as: 'projects' // this determines the name in `associations`!
 });
+Project.belongsTo(User, { foreignKey: 'ownerId', targetKey: 'id' })
 
 Address.belongsTo(User, { targetKey: 'id' });
 User.hasOne(Address, { sourceKey: 'id' });


### PR DESCRIPTION
I followed the doc, and copy all the code into my editor, when i executed `Project.find({ include: User })`, the field `user` is undefined, after reading the eagerly-loaded association part, i solve the problem. So, is the code in doc missing the `Project.belongsTo(User, { foreignKey: 'ownerId', targetKey: 'id' })`?