### PR TITLE
Replace sequelize-typescript with built-in decorators

### DIFF
--- a/docs/other-topics/hooks.md
+++ b/docs/other-topics/hooks.md
@@ -142,7 +142,7 @@ Instance Sequelize hooks can be registered in three ways:
 3. Using decorators
    ```typescript
    import { Sequelize, Model, Hook } from '@sequelize/core';
-   import { BeforeFind } from 'sequelize-typescript';
+   import { BeforeFind } from '@sequelize/core/decorators-legacy';
    
    export class MyModel extends Model {
      // highlight-next-line
@@ -192,7 +192,7 @@ Hooks added by decorators cannot be removed using the callback instance, but can
 
 ```typescript
 import { Sequelize, Model, Hook } from '@sequelize/core';
-import { BeforeFind } from 'sequelize-typescript';
+import { BeforeFind } from '@sequelize/core/decorators-legacy';
 
 export class MyModel extends Model {
   @BeforeFind({ name: 'yourHookIdentifier' })

--- a/docs/other-topics/resources.md
+++ b/docs/other-topics/resources.md
@@ -6,7 +6,7 @@ A curated list of awesome projects surrounding Sequelize.
 
 ## Integrations
 
-* [sequelize-typescript](https://www.npmjs.com/package/sequelize-typescript) - Decorators and some other features for sequelize.
+* [sequelize-typescript](https://www.npmjs.com/package/sequelize-typescript) - Decorators and some other features for sequelize (built-in as of Sequelize 7).
 * [Sequelize-Nest](https://docs.nestjs.com/recipes/sql-sequelize) - Sequelize integration in [nest](https://github.com/nestjs/nest).
 * [sequelizejs-decorators](https://www.npmjs.com/package/sequelizejs-decorators) decorators for composing sequelize models.
 

--- a/docs/other-topics/typescript.mdx
+++ b/docs/other-topics/typescript.mdx
@@ -2,14 +2,6 @@
 title: TypeScript
 ---
 
-:::info
-
-We're working hard on making Sequelize a breeze to use in TypeScript.
-[Some parts](https://github.com/sequelize/sequelize/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3ARFC+label%3A%22type%3A+typescript%22) are still a work in progress. We recommend using [sequelize-typescript](https://www.npmjs.com/package/sequelize-typescript) 
-to bridge the gap until our improvements are ready to be released.
-
-:::
-
 Sequelize provides its own TypeScript definitions.
 
 Please note that only **TypeScript >= 4.5** is supported.


### PR DESCRIPTION
As the title says

Sequelize-TypeScript won't work in v7, we'll update our documentation progressively as we add support for decorators natively