### PR TITLE
Remove false information about hooks

### DIFF
--- a/docs/other-topics/hooks.md
+++ b/docs/other-topics/hooks.md
@@ -221,6 +221,45 @@ of regular model methods, which will trigger hooks.
 
 For instance, using the `add` / `set` mixin methods will trigger the `beforeUpdate` and `afterUpdate` hooks.
 
+## `individualHooks`
+
+:::caution
+
+Using this option is discouraged for two reasons:
+
+- Unlike the "normal" hook, the data provided to events emitted by `individualHooks` cannot be modified. Only the "bulk" event's data can be modified.
+- This option is slow, as it will need to fetch the instances that need to be destroyed.
+
+Use with care. If you need to react to database changes, consider using your database's triggers and notification system instead.
+
+:::
+
+When using static model methods such as `Model.destroy` or `Model.update`, only their corresponding "bulk" hook (such as `beforeBulkDestroy`) will be called, not the instance hooks (such as `beforeDestroy`).
+
+If you want to trigger the instance hooks, you use the `individualHooks` option to the method to run the instance hooks for each row that will be impacted.  
+The following example will trigger the `beforeDestroy` and `afterDestroy` hooks for each row that will be deleted:
+
+```js
+User.destroy({
+  where: {
+    id: [1, 2, 3],
+  },
+  individualHooks: true,
+});
+```
+
+## Exceptions
+
+Only __Model methods__ trigger hooks. This means there are a number of cases where Sequelize will interact with the database without triggering hooks.
+These include but are not limited to:
+
+- Instances being deleted by the database because of an `ON DELETE CASCADE` constraint.
+- Instances being updated by the database because of a `SET NULL` or `SET DEFAULT` constraint.
+- [Raw queries](../core-concepts/raw-queries.md).
+- All QueryInterface methods.
+
+If you need to react to these events, consider using your database's native and notification system instead.
+
 ## Hooks and Transactions
 
 Many model operations in Sequelize support specifying a transaction in the options parameter of the method. 

--- a/versioned_docs/version-6.x.x/other-topics/hooks.md
+++ b/versioned_docs/version-6.x.x/other-topics/hooks.md
@@ -322,6 +322,18 @@ await Users.bulkCreate([
 });
 ```
 
+## Exceptions
+
+Only __Model methods__ trigger hooks. This means there are a number of cases where Sequelize will interact with the database without triggering hooks.
+These include but are not limited to:
+
+- Instances being deleted by the database because of an `ON DELETE CASCADE` constraint.
+- Instances being updated by the database because of a `SET NULL` or `SET DEFAULT` constraint.
+- [Raw queries](../core-concepts/raw-queries.md).
+- All QueryInterface methods.
+
+If you need to react to these events, consider using your database's native triggers and notification system instead.
+
 ## Associations
 
 For the most part hooks will work the same for instances when being associated.
@@ -329,33 +341,6 @@ For the most part hooks will work the same for instances when being associated.
 ### One-to-One and One-to-Many associations
 
 * When using `add`/`set` mixin methods the `beforeUpdate` and `afterUpdate` hooks will run.
-
-* The `beforeDestroy` and `afterDestroy` hooks will only be called on associations that have `onDelete: 'CASCADE'` and `hooks: true`. For example:
-
-```js
-class Projects extends Model {}
-Projects.init({
-  title: DataTypes.STRING
-}, { sequelize });
-
-class Tasks extends Model {}
-Tasks.init({
-  title: DataTypes.STRING
-}, { sequelize });
-
-Projects.hasMany(Tasks, { onDelete: 'CASCADE', hooks: true });
-Tasks.belongsTo(Projects);
-```
-
-This code will run `beforeDestroy` and `afterDestroy` hooks on the Tasks model.
-
-Sequelize, by default, will try to optimize your queries as much as possible. When calling cascade on delete, Sequelize will simply execute:
-
-```sql
-DELETE FROM `table` WHERE associatedIdentifier = associatedIdentifier.primaryKey
-```
-
-However, adding `hooks: true` explicitly tells Sequelize that optimization is not of your concern. Then, Sequelize will first perform a `SELECT` on the associated objects and destroy each instance, one by one, in order to be able to properly call the hooks (with the right parameters).
 
 ### Many-to-Many associations
 


### PR DESCRIPTION
As indicated in https://github.com/sequelize/sequelize/issues/2547, some of the information in the v6 documentation about hooks is false. 
The documentation says that the `hooks` option on association definitions is used to trigger hooks on association impacted by `ON DELETE CASCADE`.

I also added documentation about `individualHooks` to Sequelize 7, and added a section that details in which instances hooks do not trigger.