### PR TITLE
Re-add documentation on "hooks" cascade hack

### DIFF
--- a/docs/other-topics/hooks.md
+++ b/docs/other-topics/hooks.md
@@ -275,7 +275,7 @@ Using this option is discouraged for the following reasons:
 - If you do not run this query in a transaction, and an error occurs, you may end up with some rows deleted and some not deleted.
 - This option only works when the *instance* version of `destroy` is used. The static version will not trigger the hooks, even with `individualHooks`.
 - This option won't work in `paranoid` mode.
-- This option will not work if you only define the association on the model that has the primary key. You need to define the reverse association as well.
+- This option will not work if you only define the association on the model that owns the foreign key. You need to define the reverse association as well.
 
 This option is considered legacy. We highly recommend using your database's triggers and notification system if you need to be notified of database changes.
 

--- a/docs/other-topics/hooks.md
+++ b/docs/other-topics/hooks.md
@@ -253,12 +253,30 @@ User.destroy({
 Only __Model methods__ trigger hooks. This means there are a number of cases where Sequelize will interact with the database without triggering hooks.
 These include but are not limited to:
 
-- Instances being deleted by the database because of an `ON DELETE CASCADE` constraint.
+- Instances being deleted by the database because of an `ON DELETE CASCADE` constraint, [except if the `hooks` option is true](#hooks-for-cascade-deletes).
 - Instances being updated by the database because of a `SET NULL` or `SET DEFAULT` constraint.
 - [Raw queries](../core-concepts/raw-queries.md).
 - All QueryInterface methods.
 
 If you need to react to these events, consider using your database's native and notification system instead.
+
+## Hooks for cascade deletes
+
+As indicated in [Exceptions](#exceptions), Sequelize will not trigger hooks when instances are deleted by the database because of an `ON DELETE CASCADE` constraint.
+
+However, if you set the `hooks` option to `true` when defining your association, Sequelize will trigger the `beforeDestroy` and `afterDestroy` hooks for the deleted instances.
+
+:::caution
+
+Using this option is discouraged for the following reasons:
+
+- This option requires many extra queries. The `destroy` method normally executes a single query.
+  If this option is enabled, an extra `SELECT` query, as well as an extra `DELETE` query for each row returned by the select will be executed.
+- If you do not run this query in a transaction, and an error occurs, you may end up with some rows deleted and some not deleted.
+
+We highly recommend using your database's triggers and notification system instead.
+
+:::
 
 ## Hooks and Transactions
 

--- a/docs/other-topics/hooks.md
+++ b/docs/other-topics/hooks.md
@@ -274,7 +274,7 @@ Using this option is discouraged for the following reasons:
   If this option is enabled, an extra `SELECT` query, as well as an extra `DELETE` query for each row returned by the select will be executed.
 - If you do not run this query in a transaction, and an error occurs, you may end up with some rows deleted and some not deleted.
 - This option only works when the *instance* version of `destroy` is used. The static version will not trigger the hooks, even with `individualHooks`.
-- This option won't work in `paranoid` mode.
+- This option will not work in `paranoid` mode.
 - This option will not work if you only define the association on the model that owns the foreign key. You need to define the reverse association as well.
 
 This option is considered legacy. We highly recommend using your database's triggers and notification system if you need to be notified of database changes.

--- a/versioned_docs/version-6.x.x/other-topics/hooks.md
+++ b/versioned_docs/version-6.x.x/other-topics/hooks.md
@@ -336,8 +336,6 @@ If you need to react to these events, consider using your database's native trig
 
 ## Hooks for cascade deletes
 
-## Hooks for cascade deletes
-
 As indicated in [Exceptions](#exceptions), Sequelize will not trigger hooks when instances are deleted by the database because of an `ON DELETE CASCADE` constraint.
 
 However, if you set the `hooks` option to `true` when defining your association, Sequelize will trigger the `beforeDestroy` and `afterDestroy` hooks for the deleted instances.
@@ -350,7 +348,7 @@ Using this option is discouraged for the following reasons:
   If this option is enabled, an extra `SELECT` query, as well as an extra `DELETE` query for each row returned by the select will be executed.
 - If you do not run this query in a transaction, and an error occurs, you may end up with some rows deleted and some not deleted.
 - This option only works when the *instance* version of `destroy` is used. The static version will not trigger the hooks, even with `individualHooks`.
-- This option won't work in `paranoid` mode.
+- This option will not work in `paranoid` mode.
 - This option will not work if you only define the association on the model that owns the foreign key. You need to define the reverse association as well.
 
 This option is considered legacy. We highly recommend using your database's triggers and notification system if you need to be notified of database changes.

--- a/versioned_docs/version-6.x.x/other-topics/hooks.md
+++ b/versioned_docs/version-6.x.x/other-topics/hooks.md
@@ -351,7 +351,7 @@ Using this option is discouraged for the following reasons:
 - If you do not run this query in a transaction, and an error occurs, you may end up with some rows deleted and some not deleted.
 - This option only works when the *instance* version of `destroy` is used. The static version will not trigger the hooks, even with `individualHooks`.
 - This option won't work in `paranoid` mode.
-- This option will not work if you only define the association on the model that has the primary key. You need to define the reverse association as well.
+- This option will not work if you only define the association on the model that owns the foreign key. You need to define the reverse association as well.
 
 This option is considered legacy. We highly recommend using your database's triggers and notification system if you need to be notified of database changes.
 

--- a/versioned_docs/version-6.x.x/other-topics/hooks.md
+++ b/versioned_docs/version-6.x.x/other-topics/hooks.md
@@ -327,12 +327,30 @@ await Users.bulkCreate([
 Only __Model methods__ trigger hooks. This means there are a number of cases where Sequelize will interact with the database without triggering hooks.
 These include but are not limited to:
 
-- Instances being deleted by the database because of an `ON DELETE CASCADE` constraint.
+- Instances being deleted by the database because of an `ON DELETE CASCADE` constraint, [except if the `hooks` option is true](#hooks-for-cascade-deletes).
 - Instances being updated by the database because of a `SET NULL` or `SET DEFAULT` constraint.
 - [Raw queries](../core-concepts/raw-queries.md).
 - All QueryInterface methods.
 
 If you need to react to these events, consider using your database's native triggers and notification system instead.
+
+## Hooks for cascade deletes
+
+As indicated in [Exceptions](#exceptions), Sequelize will not trigger hooks when instances are deleted by the database because of an `ON DELETE CASCADE` constraint.
+
+However, if you set the `hooks` option to `true` when defining your association, Sequelize will trigger the `beforeDestroy` and `afterDestroy` hooks for the deleted instances.
+
+:::caution
+
+Using this option is discouraged for the following reasons:
+
+- This option requires many extra queries. The `destroy` method normally executes a single query.
+  If this option is enabled, an extra `SELECT` query, as well as an extra `DELETE` query for each row returned by the select will be executed.
+- If you do not run this query in a transaction, and an error occurs, you may end up with some rows deleted and some not deleted.
+
+We highly recommend using your database's triggers and notification system instead.
+
+:::
 
 ## Associations
 


### PR DESCRIPTION
Sorry @WikiRik I jumped the gun too quickly on this one and my test had a flaw. Turned out the feature *does* exist but it uses the same option name as a different option (which is horrible, but I'll fix that in a separate PR)

This PR adds the documentation back, but adds a warning that using it is discouraged. We should look into providing trigger support instead of hacks like `individualHooks` and this option