### PR TITLE
Fix: mistake in example of creating with alias

### DIFF
--- a/versioned_docs/version-6.x.x/advanced-association-concepts/creating-with-associations.md
+++ b/versioned_docs/version-6.x.x/advanced-association-concepts/creating-with-associations.md
@@ -55,7 +55,7 @@ return Product.create({
   }
 }, {
   include: [{
-    association: Product.User,
+    model: Product.User,
     include: [ User.Addresses ]
   }]
 });
@@ -126,7 +126,7 @@ Product.create({
   ]
 }, {
   include: [{
-    association: Categories,
+    model: Categories,
     as: 'categories'
   }]
 })


### PR DESCRIPTION
While creating object with associations with alias, you should pass 'model' instead of 'association' for model name in the include section. If you pass `association: Categories`, the `categories` property would be ignored.