### PR TITLE
docs: updated broken link with v6 query-types

### DIFF
--- a/docs/core-concepts/raw-queries.md
+++ b/docs/core-concepts/raw-queries.md
@@ -20,7 +20,7 @@ const users = await sequelize.query("SELECT * FROM `users`", { type: QueryTypes.
 // We didn't need to destructure the result here - the results were returned directly
 ```
 
-Several other query types are available. [Peek into the source for details](https://github.com/sequelize/sequelize/blob/main/src/query-types.ts).
+Several other query types are available. [Peek into the source for details](https://github.com/sequelize/sequelize/blob/v6/src/query-types.js).
 
 A second option is the model. If you pass a model the returned data will be instances of that model.
 


### PR DESCRIPTION
### Description

Since `v7` is not out yet this links points to the `v7` repository's `query-types`. Updated it to point to `v6` `query-types.js`.
