### PR TITLE
Document `afterPoolAcquire` & `beforePoolAcquire`

### DIFF
--- a/docs/other-topics/hooks.md
+++ b/docs/other-topics/hooks.md
@@ -36,7 +36,7 @@ Sequelize.hooks.addListener('beforeInit', () => {
 | `beforeBulkSync`, `afterBulkSync`     | ✅     | `sequelize.sync` is called                                 |
 | `beforeConnect`, `afterConnect`       | ✅     | Whenever a new connection to the database is being created |
 | `beforeDisconnect`, `afterDisconnect` | ✅     | Whenever a connection to the database is being closed      |
-| `beforePoolConnection`, `afterPoolConnection` | ✅     | Whenever a new connection from pool is being acquired |
+| `beforePoolAcquire`, `afterPoolAcquire` | ✅     | Whenever a new connection from pool is being acquired |
 
 :::info
 

--- a/docs/other-topics/hooks.md
+++ b/docs/other-topics/hooks.md
@@ -36,6 +36,7 @@ Sequelize.hooks.addListener('beforeInit', () => {
 | `beforeBulkSync`, `afterBulkSync`     | ✅     | `sequelize.sync` is called                                 |
 | `beforeConnect`, `afterConnect`       | ✅     | Whenever a new connection to the database is being created |
 | `beforeDisconnect`, `afterDisconnect` | ✅     | Whenever a connection to the database is being closed      |
+| `beforePoolConnection`, `afterPoolConnection` | ✅     | Whenever a new connection from pool is being acquired |
 
 :::info
 

--- a/versioned_docs/version-6.x.x/other-topics/hooks.md
+++ b/versioned_docs/version-6.x.x/other-topics/hooks.md
@@ -227,6 +227,12 @@ sequelize.beforeConnect(async (config) => {
   config.password = await getAuthToken();
 });
 ```
+You can also use two hooks that are executed immediately before and after a pool connection is acquired:
+
+* `sequelize.beforePoolConnection(callback)`
+  * The callback has the form `async (config) => /* ... */`
+* `sequelize.afterPoolConnection(callback)`
+  * The callback has the form `async (connection, config) => /* ... */`
 
 These hooks may *only* be declared as a permanent global hook, as the connection pool is shared by all models.
 

--- a/versioned_docs/version-6.x.x/other-topics/hooks.md
+++ b/versioned_docs/version-6.x.x/other-topics/hooks.md
@@ -229,9 +229,9 @@ sequelize.beforeConnect(async (config) => {
 ```
 You can also use two hooks that are executed immediately before and after a pool connection is acquired:
 
-* `sequelize.beforePoolConnection(callback)`
+* `sequelize.beforePoolAcquire(callback)`
   * The callback has the form `async (config) => /* ... */`
-* `sequelize.afterPoolConnection(callback)`
+* `sequelize.afterPoolAcquire(callback)`
   * The callback has the form `async (connection, config) => /* ... */`
 
 These hooks may *only* be declared as a permanent global hook, as the connection pool is shared by all models.


### PR DESCRIPTION
Updated documentation for this issue: https://github.com/sequelize/sequelize/issues/15724