### PR TITLE
docs: update TypeScript version support

### DIFF
--- a/src/pages/releases.mdx
+++ b/src/pages/releases.mdx
@@ -12,7 +12,7 @@ This page regroups information related to which engines versions are supported b
 
 | Sequelize                       |  [Node.js][node-releases]  | [Typescript][ts-releases] | Release Date | EOL        |
 |---------------------------------|----------------------------|---------------------------|--------------|------------|
-| [7 (alpha)][sequelize-core]     | ^14.17.0 \|\| >= 16.0.0    | >= 4.6                    | ❓           | ❓         |
+| [7 (alpha)][sequelize-core]     | ^14.17.0 \|\| >= 16.0.0    | >= 4.7                    | ❓           | ❓         |
 | [6 (current)][sequelize-legacy] | >= 10                      | >= 4.1                    | 2020-06-24   | ❓         |
 | 5 (eol)                         | >=6                        | >= 3.1                    | 2019-03-13   | 2022-01-01 |
 


### PR DESCRIPTION
@ephys I will not touch the TypeScript page in our docs since I assume you will do that as part of #330 

See https://github.com/sequelize/sequelize/pull/15877