### PR TITLE
Remove Model from usage example on homepage

### DIFF
--- a/src/components/homepage-usage.tsx
+++ b/src/components/homepage-usage.tsx
@@ -31,7 +31,7 @@ export default function HomepageUsage(): JSX.Element {
             <h2>Define models</h2>
             <CodeBlock language="js">
               {trim`
-                import { Sequelize, Model, DataTypes } from 'sequelize';
+                import { Sequelize, DataTypes } from 'sequelize';
 
                 const sequelize = new Sequelize('sqlite::memory:');
                 const User = sequelize.define('User', {


### PR DESCRIPTION
This is a minor change to the usage example on the homepage.
The `Model` import isn't necessary, so it seemed better not to import it in the example, just to avoid any confusion.
