### PR TITLE
fix: drop support for Node 14

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 
 Sequelize is a promise-based [Node.js](https://nodejs.org/en/about/) [ORM tool](https://en.wikipedia.org/wiki/Object-relational_mapping) for [Postgres](https://en.wikipedia.org/wiki/PostgreSQL), [MySQL](https://en.wikipedia.org/wiki/MySQL), [MariaDB](https://en.wikipedia.org/wiki/MariaDB), [SQLite](https://en.wikipedia.org/wiki/SQLite), [Microsoft SQL Server](https://en.wikipedia.org/wiki/Microsoft_SQL_Server), [Amazon Redshift](https://docs.aws.amazon.com/redshift/index.html) and [Snowflake’s Data Cloud](https://docs.snowflake.com/en/user-guide/intro-key-concepts.html). It features solid transaction support, relations, eager and lazy loading, read replication and more.
 
-Sequelize follows [Semantic Versioning](https://semver.org) and the [official Node.js LTS schedule](https://nodejs.org/en/about/releases/). Version 7 of Sequelize officially supports the Node.js versions `^14.17,0`, `^16.0.0`. Other version might be working as well.
+Sequelize follows [Semantic Versioning](https://semver.org) and the [official Node.js LTS schedule](https://nodejs.org/en/about/releases/). Version 7 of Sequelize officially supports the Node.js versions `>=16.0.0`.
 
 You are currently looking at the **Tutorials and Guides** for Sequelize. You might also be interested in the [API Reference](pathname:///api/v7).
 

--- a/docs/other-topics/upgrade.md
+++ b/docs/other-topics/upgrade.md
@@ -32,7 +32,7 @@ await sequelize.authenticate();
 Sequelize v7 only supports the versions of Node.js, and databases that were not EOL at the time of release.[^issue-1]  
 Sequelize v7 also supports versions of TypeScript that were released in the past year prior to the time of release.
 
-This means Sequelize v7 supports **Node ^14.17.0 || >=16.0.0**, and **TypeScript >= 4.5**.
+This means Sequelize v7 supports **>=16.0.0**, and **TypeScript >= 4.7**.
 
 Head to our [Versioning Policy page](/releases) to see exactly which databases are supported by Sequelize v7.
 

--- a/src/pages/releases.mdx
+++ b/src/pages/releases.mdx
@@ -12,7 +12,7 @@ This page regroups information related to which engines versions are supported b
 
 | Sequelize                       |  [Node.js][node-releases]  | [Typescript][ts-releases] | Release Date | EOL        |
 |---------------------------------|----------------------------|---------------------------|--------------|------------|
-| [7 (alpha)][sequelize-core]     | ^14.17.0 \|\| >= 16.0.0    | >= 4.7                    | ❓           | ❓         |
+| [7 (alpha)][sequelize-core]     | >= 16.0.0                  | >= 4.7                    | ❓           | ❓         |
 | [6 (current)][sequelize-legacy] | >= 10                      | >= 4.1                    | 2020-06-24   | ❓         |
 | 5 (eol)                         | >=6                        | >= 3.1                    | 2019-03-13   | 2022-01-01 |
 


### PR DESCRIPTION
See https://github.com/sequelize/sequelize/pull/16058