### PR TITLE
FIX : Typo Error in the increment function

### DIFF
--- a/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
+++ b/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
@@ -710,6 +710,6 @@ Sequelize also provides the `increment` convenience method.
 Let's assume we have a user, whose age is 10.
 
 ```js
-await User.increment({age: 5}, { where: { id: 1 } }) // Will increase age to 15
+await User.increment({age: 5}, { where: { id: 1 } }) // Will increase age to 5
 await User.increment({age: -5}, { where: { id: 1 } }) // Will decrease age to 5
 ```


### PR DESCRIPTION
In the increment and decrement functions, updated a type error in the comments of increment function.

old line : 
await User.increment({age: 5}, { where: { id: 1 } }) // Will increase age to 15

updated line : 
await User.increment({age: 5}, { where: { id: 1 } }) // Will increase age to 5