### PR TITLE
Added a link to `sequelize-browser` package

### DIFF
--- a/versioned_docs/version-6.x.x/other-topics/resources.md
+++ b/versioned_docs/version-6.x.x/other-topics/resources.md
@@ -27,6 +27,10 @@ title: Resources
 
 * [sequelize-bcrypt](https://github.com/mattiamalonni/sequelize-bcrypt) - Utility to integrate bcrypt into sequelize models
 
+### Browser
+
+* [sequelize-browser](https://npmjs.com/package/sequelize-browser) - A web-browser-compatible build of Sequelize
+
 ### Caching
 
 * [sequelize-transparent-cache](https://github.com/DanielHreben/sequelize-transparent-cache)


### PR DESCRIPTION
Added a link to `sequelize-browser` package on the Resources page. https://npmjs.com/package/sequelize-browser

Related PR: https://github.com/sequelize/sequelize/pull/16208
Related issue: https://github.com/sequelize/sequelize/issues/16207