### PR TITLE
docs(migrations): fix addIndex fields should be an array

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -240,9 +240,8 @@ module.exports = {
       );
       await queryInterface.addIndex(
         'Person',
-        'petName',
+        ['petName'],
         {
-          fields: 'petName',
           unique: true,
           transaction,
         }

--- a/versioned_docs/version-6.x.x/other-topics/migrations.md
+++ b/versioned_docs/version-6.x.x/other-topics/migrations.md
@@ -306,9 +306,8 @@ module.exports = {
       );
       await queryInterface.addIndex(
         'Person',
-        'petName',
+        ['petName'],
         {
-          fields: 'petName',
           unique: true,
           transaction,
         }


### PR DESCRIPTION
It seems `addIndex` `fields` should be an array.

According to: https://sequelize.org/api/v6/class/src/dialects/abstract/query-interface.js~queryinterface