### PR TITLE
docs: fix bidirectional association examples in v7 upgrade guide

### DIFF
--- a/docs/other-topics/upgrade.md
+++ b/docs/other-topics/upgrade.md
@@ -295,14 +295,14 @@ This lead to subtle bugs, so starting with v7, associations options must perfect
 For instance, the following declaration is no longer valid:
 
 ```typescript
-User.belongsToMany(Countries, { foreignKey: 'user_id' });
-Countries.belongsToMany(User);
+User.belongsToMany(Country, { foreignKey: 'user_id' });
+Country.belongsToMany(User);
 ```
 
 But this is:
 
 ```typescript
-User.belongsToMany(User, { foreignKey: 'user_id' });
+User.belongsToMany(Country, { foreignKey: 'user_id' });
 Country.belongsToMany(User, { otherKey: 'user_id' });
 ```
 
@@ -315,7 +315,7 @@ Instead of writing this:
 
 ```typescript
 User.belongsToMany(Country, { as: 'countries' });
-User.belongsToMany(User, { as: 'citizen' });
+Country.belongsToMany(User, { as: 'citizens' });
 ```
 
 You can now write this:
@@ -323,7 +323,7 @@ You can now write this:
 ```typescript
 User.belongsToMany(Country, { 
   as: 'countries',
-  inverse: { as: 'citizen' },
+  inverse: { as: 'citizens' },
 });
 ```
 


### PR DESCRIPTION
Fixed bidirectional examples that were inconsistent. 

- The model `Country` and `Countries` was used. I updated all of the models in the example to use singular names.
- Updated association aliases to be plural names `citizen` -> `citizens` as recommended for many-to-many associations
- Fixed an error associating User to User (`User.belongsToMany(User, { foreignKey: 'user_id' });`) instead of to Country as further explained in the example

Thanks for the work on v7, it's looking great. I'd be happy to make changes if I misunderstood the intent of the examples here.