### PR TITLE
Fix links to API v7 docs in model-typeing.md and utility-types.md

### DIFF
--- a/docs/models/model-typing.mdx
+++ b/docs/models/model-typing.mdx
@@ -10,8 +10,8 @@ sidebar_position: 8
 Model methods are strictly typed based on your attributes, but require you to define you to write a bit of configuration first.
 `Model` accept two generic types that you can use to let it know what its Attributes & Creation Attributes are like:
 
-You can use [`InferAttributes`](pathname:///api/v7/index.html#InferAttributes),
-and [`InferCreationAttributes`](pathname:///api/v7/index.html#InferCreationAttributes) to define them. They will extract Attribute typings
+You can use [`InferAttributes`](pathname:///api/v7/types/_sequelize_core.index.inferattributes),
+and [`InferCreationAttributes`](pathname:///api/v7/types/_sequelize_core.index.infercreationattributes) to define them. They will extract Attribute typings
 directly from the Model:
 
 ```typescript
@@ -37,22 +37,22 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
 await User.create({ nAme: 'john' });
 ```
 
-Important things to know about how [`InferAttributes`](pathname:///api/v7/index.html#InferAttributes) & [`InferCreationAttributes`](pathname:///api/v7/index.html#InferCreationAttributes) work,
+Important things to know about how [`InferAttributes`](pathname:///api/v7/types/_sequelize_core.index.inferattributes) & [`InferCreationAttributes`](pathname:///api/v7/types/_sequelize_core.index.infercreationattributes) work,
 they will select all declared properties of the class, except for:
 
 - Static fields and methods.
 - Methods (anything whose type is a function).
-- Those whose type uses the branded type [`NonAttribute`](pathname:///api/v7/index.html#NonAttribute).
+- Those whose type uses the branded type [`NonAttribute`](pathname:///api/v7/types/_sequelize_core.index.nonattribute).
 - Those excluded by using InferAttributes like this: `InferAttributes<User, { omit: 'properties' | 'to' | 'omit' }>`.
 - Those declared by the Model superclass (but not intermediary classes!).
   If one of your attributes shares the same name as one of the properties of [`Model`](pathname:///api/v7/classes/_sequelize_core.index.Model.html), change its name.
   Doing this is likely to cause issues anyway.
-- Getter & setters are not automatically excluded. Set their return / parameter type to [`NonAttribute`](pathname:///api/v7/index.html#NonAttribute),
+- Getter & setters are not automatically excluded. Set their return / parameter type to [`NonAttribute`](pathname:///api/v7/types/_sequelize_core.index.nonattribute),
   or add them to `omit` to exclude them.
 
-[`InferCreationAttributes`](pathname:///api/v7/index.html#InferCreationAttributes) works the same way as [`InferAttributes`](pathname:///api/v7/index.html#InferAttributes)
-with one exception; properties typed using the [`CreationOptional`](pathname:///api/v7/index.html#CreationOptional) type will be marked as optional.
-Note that attributes that accept `null`, or `undefined` do not need to use [`CreationOptional`](pathname:///api/v7/index.html#CreationOptional):
+[`InferCreationAttributes`](pathname:///api/v7/types/_sequelize_core.index.infercreationattributes) works the same way as [`InferAttributes`](pathname:///api/v7/types/_sequelize_core.index.inferattributes)
+with one exception; properties typed using the [`CreationOptional`](pathname:///api/v7/types/_sequelize_core.index.creationoptional) type will be marked as optional.
+Note that attributes that accept `null`, or `undefined` do not need to use [`CreationOptional`](pathname:///api/v7/types/_sequelize_core.index.creationoptional):
 
 ```typescript
 export class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {

--- a/docs/other-topics/utility-types.md
+++ b/docs/other-topics/utility-types.md
@@ -2,7 +2,7 @@
 
 ## Typing a Model Class
 
-[`ModelStatic`](pathname:///api/v7/index.html#ModelStatic) is designed to be used to type a Model *class*.
+[`ModelStatic`](pathname:///api/v7/types/_sequelize_core.index.modelstatic) is designed to be used to type a Model *class*.
 
 Here is an example of a utility method that requests a Model Class, and returns the list of primary keys defined in that class:
 
@@ -41,17 +41,17 @@ const primaryAttributes = getPrimaryKeyAttributes(User);
 ## Getting a Model's attributes
 
 If you need to access the list of attributes of a given model,
-[`Attributes<Model>`](pathname:///api/v7/index.html#Attributes) and [`CreationAttributes<Model>`](pathname:///api/v7/index.html#CreationAttributes)
+[`Attributes<Model>`](pathname:///api/v7/types/_sequelize_core.index.attributes) and [`CreationAttributes<Model>`](pathname:///api/v7/types/_sequelize_core.index.creationattributes)
 are what you need to use.
 
 They will return the Attributes (and Creation Attributes) of the Model passed as a parameter.
 
-Don't confuse them with [`InferAttributes`](pathname:///api/v7/index.html#InferAttributes)
-and [`InferCreationAttributes`](pathname:///api/v7/index.html#InferCreationAttributes). These two utility types should only ever be used
+Don't confuse them with [`InferAttributes`](pathname:///api/v7/types/_sequelize_core.index.inferattributes)
+and [`InferCreationAttributes`](pathname:///api/v7/types/_sequelize_core.index.infercreationattributes). These two utility types should only ever be used
 in the definition of a Model to automatically create the list of attributes from the model's public class fields. They only work
 with class-based model definitions (when using [`Model.init`](pathname:///api/v7/classes/_sequelize_core.index.Model.html#init)).
 
-[`Attributes<Model>`](pathname:///api/v7/index.html#Attributes) and [`CreationAttributes<Model>`](pathname:///api/v7/index.html#CreationAttributes)
+[`Attributes<Model>`](pathname:///api/v7/types/_sequelize_core.index.attributes) and [`CreationAttributes<Model>`](pathname:///api/v7/types/_sequelize_core.index.creationattributes)
 will return the list of attributes of any model, no matter how they were created (be it [`Model.init`](pathname:///api/v7/classes/_sequelize_core.index.Model.html#init)
 or [`Sequelize#define`](pathname:///api/v7/classes/_sequelize_core.index.Sequelize.html#define)).
 


### PR DESCRIPTION
I noticed the links to the API docs in [Typing your model](https://sequelize.org/docs/v7/models/model-typing/) and [Utility TypeScript types](https://sequelize.org/docs/v7/other-topics/utility-types/) were broken, so I tried to fix them.

But there seems to be some sort of URL rewriting happening on the live website that doesn't happen in the local build. For example InferAttributes is at `http://localhost:3000/api/v7/types/_sequelize_core.index.InferAttributes.html` in the local build and at `https://sequelize.org/api/v7/types/_sequelize_core.index.inferattributes` on the live website.