### PR TITLE
nit: fix typo

### DIFF
--- a/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
+++ b/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
@@ -637,7 +637,7 @@ To recap, the elements of the order array can be the following:
   * The content of `raw` will be added verbatim without quoting
   * Everything else is ignored, and if raw is not set, the query will fail
 * A call to `Sequelize.fn` (which will generate a function call in SQL)
-* A call to `Sequelize.col` (which will quoute the column name)
+* A call to `Sequelize.col` (which will quote the column name)
 
 ### Grouping
 


### PR DESCRIPTION
`quoute` was misspelled, so I rightfully changed it to `quote`.