### PR TITLE
Removed return type annotator from setter function

### DIFF
--- a/docs/models/getters-setters-virtuals.md
+++ b/docs/models/getters-setters-virtuals.md
@@ -119,7 +119,7 @@ class User extends Model {
   
   @Attribute(DataTypes.STRING)
   @NotNull
-  set password(value): string {
+  set password(value) {
     // Accessing the value of another attribute inside the setter can lead to unexpected results
     // error-next-line
     this.setDataValue('password', hash(this.username + value));


### PR DESCRIPTION
Setter function had return type annotator which is illegal in TypeScript.