### PR TITLE
Update dialect-specific-things.md

### DIFF
--- a/versioned_docs/version-6.x.x/other-topics/dialect-specific-things.md
+++ b/versioned_docs/version-6.x.x/other-topics/dialect-specific-things.md
@@ -98,7 +98,7 @@ To connect over a unix domain socket, specify the path to the socket directory i
 ```js
 const sequelize = new Sequelize('database', 'username', 'password', {
   dialect: 'postgres',
-  host: '/path/to/socket_directory'
+  socketPath: '/path/to/socket_directory'
 });
 ```
 


### PR DESCRIPTION
Fixes code sample that showed the key `host` instead of `socketPath` when connecting via a socket