### PR TITLE
Drop MySQL 5.7 support in v7

### DIFF
--- a/docs/models/defining-models.mdx
+++ b/docs/models/defining-models.mdx
@@ -336,12 +336,6 @@ class User extends Model {
 Sequelize also provides 2 built-in functions, [`sql.uuidV1` and `sql.uuidV4`](./data-types.mdx#built-in-default-values-for-uuid), that will
 generate a UUID in SQL if possible, and fallback to a JavaScript implementation otherwise.
 
-:::info
-
-In MySQL, it is only possible to use dynamic SQL default values starting with version [8.0.13](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html).
-
-:::
-
 ## Primary Keys
 
 Sequelize automatically adds an auto-incremented integer attribute called `id` as primary key if none is specified.

--- a/docs/other-topics/dialect-specific-things.md
+++ b/docs/other-topics/dialect-specific-things.md
@@ -280,7 +280,7 @@ Project.findAll({
 
 The `indexHints` option can be used to define index hints. The hint type must be a value from `IndexHints` and the values should reference existing indexes.
 
-Index hints [override the default behavior of the MySQL query optimizer](https://dev.mysql.com/doc/refman/5.7/en/index-hints.html).
+Index hints [override the default behavior of the MySQL query optimizer](https://dev.mysql.com/doc/refman/8.0/en/index-hints.html).
 
 ```js
 import { IndexHints } from '@sequelize/core';

--- a/src/pages/releases.mdx
+++ b/src/pages/releases.mdx
@@ -65,7 +65,7 @@ MySQL requires the use of the [mysql2] npm package.
 
 | Sequelize   | [MySQL][mysql] | [mysql2] |
 |-------------|----------------|----------|
-| 7 (alpha)   | >=8.0.19       | >= 3.9.1 |
+| 7 (alpha)   | >=8.0.19       | >= 3.8.0 |
 | 6 (current) | ^5.7, ^8.0     | >= 2.3.3 |
 
 [mysql]: https://endoflife.date/mysql

--- a/src/pages/releases.mdx
+++ b/src/pages/releases.mdx
@@ -65,7 +65,7 @@ MySQL requires the use of the [mysql2] npm package.
 
 | Sequelize   | [MySQL][mysql] | [mysql2] |
 |-------------|----------------|----------|
-| 7 (alpha)   | ^5.7, ^8.0     | >= 2.3.3 |
+| 7 (alpha)   | >=8.0.19       | >= 3.9.1 |
 | 6 (current) | ^5.7, ^8.0     | >= 2.3.3 |
 
 [mysql]: https://endoflife.date/mysql

--- a/versioned_docs/version-6.x.x/other-topics/dialect-specific-things.md
+++ b/versioned_docs/version-6.x.x/other-topics/dialect-specific-things.md
@@ -276,7 +276,7 @@ Project.findAll({
 
 The `indexHints` option can be used to define index hints. The hint type must be a value from `IndexHints` and the values should reference existing indexes.
 
-Index hints [override the default behavior of the MySQL query optimizer](https://dev.mysql.com/doc/refman/5.7/en/index-hints.html).
+Index hints [override the default behavior of the MySQL query optimizer](https://dev.mysql.com/doc/refman/8.0/en/index-hints.html).
 
 ```js
 const { IndexHints } = require("sequelize");

--- a/versioned_docs/version-6.x.x/other-topics/dialect-specific-things.md
+++ b/versioned_docs/version-6.x.x/other-topics/dialect-specific-things.md
@@ -276,7 +276,7 @@ Project.findAll({
 
 The `indexHints` option can be used to define index hints. The hint type must be a value from `IndexHints` and the values should reference existing indexes.
 
-Index hints [override the default behavior of the MySQL query optimizer](https://dev.mysql.com/doc/refman/8.0/en/index-hints.html).
+Index hints [override the default behavior of the MySQL query optimizer](https://dev.mysql.com/doc/refman/5.7/en/index-hints.html).
 
 ```js
 const { IndexHints } = require("sequelize");


### PR DESCRIPTION
Updating the supported versions for MySQL for `@sequelize/core` version 7 as per sequelize/sequelize#17029