### PR TITLE
Update the type used in examples for optional creation attributes.

### DIFF
--- a/docs/models/model-typing.mdx
+++ b/docs/models/model-typing.mdx
@@ -81,7 +81,8 @@ Example of a minimal TypeScript project with strict type-checking for attributes
 although it is much more verbose:
 
 ```typescript
-import { Model, Optional } from '@sequelize/core';
+import { Model } from '@sequelize/core';
+import type { PartialBy } from '@sequelize/utils';
 
 type UserAttributes = {
   id: number,
@@ -90,7 +91,7 @@ type UserAttributes = {
 
 // we're telling the Model that 'id' is optional
 // when creating an instance of the model (such as using Model.create()).
-type UserCreationAttributes = Optional<UserAttributes, 'id'>;
+type UserCreationAttributes = PartialBy<UserAttributes, 'id'>;
 
 class User extends Model<UserAttributes, UserCreationAttributes> {
   @Attribute(DataTypes.INTEGER)

--- a/versioned_docs/version-6.x.x/other-topics/typescript.md
+++ b/versioned_docs/version-6.x.x/other-topics/typescript.md
@@ -30,7 +30,8 @@ See [Caveat with Public Class Fields](../core-concepts/model-basics.md#caveat-wi
 Sequelize Models accept two generic types to define what the model's Attributes & Creation Attributes are like:
 
 ```typescript
-import { Model, Optional } from 'sequelize';
+import { Model } from 'sequelize';
+import type { PartialBy } from '@sequelize/utils';
 
 // We don't recommend doing this. Read on for the new way of declaring Model typings.
 
@@ -42,7 +43,7 @@ type UserAttributes = {
 
 // we're telling the Model that 'id' is optional
 // when creating an instance of the model (such as using Model.create()).
-type UserCreationAttributes = Optional<UserAttributes, 'id'>;
+type UserCreationAttributes = PartialBy<UserAttributes, 'id'>;
 
 class User extends Model<UserAttributes, UserCreationAttributes> {
   declare id: number;

--- a/versioned_docs/version-6.x.x/other-topics/typescript.md
+++ b/versioned_docs/version-6.x.x/other-topics/typescript.md
@@ -30,8 +30,7 @@ See [Caveat with Public Class Fields](../core-concepts/model-basics.md#caveat-wi
 Sequelize Models accept two generic types to define what the model's Attributes & Creation Attributes are like:
 
 ```typescript
-import { Model } from 'sequelize';
-import type { PartialBy } from '@sequelize/utils';
+import { Model, Optional } from 'sequelize';
 
 // We don't recommend doing this. Read on for the new way of declaring Model typings.
 
@@ -43,7 +42,7 @@ type UserAttributes = {
 
 // we're telling the Model that 'id' is optional
 // when creating an instance of the model (such as using Model.create()).
-type UserCreationAttributes = PartialBy<UserAttributes, 'id'>;
+type UserCreationAttributes = Optional<UserAttributes, 'id'>;
 
 class User extends Model<UserAttributes, UserCreationAttributes> {
   declare id: number;


### PR DESCRIPTION
The type `Optional` was renamed to `PartialBy` and is available in [@sequelize/utils](https://github.com/sequelize/sequelize/tree/main/packages/utils).

The documentation needed to be updated to reflect the change.

This fixes #716.