### PR TITLE
align workflows & metadata with main repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sequelize/code-reviewers

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: sequelize
 patreon: # Replace with a single Patreon username
 open_collective: sequelize
 ko_fi: # Replace with a single Ko-fi username

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,0 +1,40 @@
+name: auto-update PRs & label conflicts
+on:
+  push:
+    branches:
+      - main
+  # can also be used with the pull_request event
+  pull_request_target:
+    types:
+      - synchronize
+      # allow the workflow to correct any label incorrectly added or removed by a user.
+      - labeled
+      - unlabeled
+      # update the PR as soon as the auto-merge is enabled.
+      - auto_merge_enabled
+      # process the PR once they appear in the search filters
+      - ready_for_review
+      - opened
+      - reopened
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Sequelize Bot Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
+          private-key: '${{ secrets.SEQUELIZE_BOT_PRIVATE_KEY }}'
+      - uses: sequelize/pr-auto-update-and-handle-conflicts@3ff4c1ae3b521ccd0a6bed0de19911d555b7da8d # 1.0.0
+        with:
+          conflict-label: 'conflicted'
+          conflict-requires-ready-state: 'ready_for_review'
+          conflict-excluded-authors: 'bot/renovate'
+          update-pr-branches: true
+          update-requires-auto-merge: true
+          update-requires-ready-state: 'ready_for_review'
+          update-excluded-authors: 'bot/renovate'
+          update-excluded-labels: 'no-autoupdate'
+        env:
+          GITHUB_TOKEN: '${{ steps.generate-token.outputs.token }}'


### PR DESCRIPTION
This PR implements the same workflow as https://github.com/sequelize/sequelize/pull/17271, but for the website repository

It also adds the codeowner file for automatic reviewer assignation, as well as updates the funding file