### PR TITLE
add usage trend

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -24,15 +24,23 @@ Sequelize follows [Semantic Versioning](https://semver.org) and the [official No
 You are currently looking at the **Tutorials and Guides** for Sequelize. You might also be interested in the [API Reference](pathname:///api/v7).
 
 [Usage Trend of sequelize@6](https://npm-compare.com/sequelize#timeRange=THREE_YEARS):
-  
+
 <a href="https://npm-compare.com/sequelize#timeRange=THREE_YEARS" target="_blank">
-  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/sequelize.png" width="60%" alt="NPM Usage Trend of sequelize" />
+  <img
+    src="https://npm-compare.com/img/npm-trend/THREE_YEARS/sequelize.png"
+    width="60%"
+    alt="NPM Usage Trend of sequelize"
+  />
 </a>
 
 [Usage Trend of Sequelize@7](https://npm-compare.com/@sequelize/core#timeRange=THREE_YEARS):
-  
+
 <a href="https://npm-compare.com/@sequelize/core#timeRange=THREE_YEARS" target="_blank">
-  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/@sequelize/core.png" width="60%" alt="NPM Usage Trend of @sequelize/core" />
+  <img
+    src="https://npm-compare.com/img/npm-trend/THREE_YEARS/@sequelize/core.png"
+    width="60%"
+    alt="NPM Usage Trend of @sequelize/core"
+  />
 </a>
 
 ## Quick example


### PR DESCRIPTION
I'm an active user of sequelize and I'm really impressed with its capabilities. As sequelize's popularity has grown significantly in recent years, I believe it would be helpful to include a resource in the README to assist new users who are choosing an nodejs ORM solution.

I believe this can provide value to new users and the sequelize community. Thank you for your consideration