### PR TITLE
docs: fixing MariaDbDialect documentation

### DIFF
--- a/docs/databases/mariadb.mdx
+++ b/docs/databases/mariadb.mdx
@@ -17,14 +17,14 @@ To use Sequelize with MariaDB, you need to install the `@sequelize/mariadb` dial
 npm i @sequelize/mariadb
 ```
 
-Then use the `MariaDBDialect` class as the dialect option in the Sequelize constructor:
+Then use the `MariaDbDialect` class as the dialect option in the Sequelize constructor:
 
 ```ts
 import { Sequelize } from '@sequelize/core';
-import { MariaDBDialect } from '@sequelize/mariadb';
+import { MariaDbDialect } from '@sequelize/mariadb';
 
 const sequelize = new Sequelize({
-  dialect: MariaDBDialect,
+  dialect: MariaDbDialect,
   database: 'mydb',
   user: 'myuser',
   password: 'mypass',


### PR DESCRIPTION
The type 'MariaDBDialect' doesn't exist and should be fixed to 'MariaDbDialect' like the code exports:
https://github.com/sequelize/sequelize/blob/b97a9b921dbec7c4a892c89ee03c7790ba48db8a/packages/mariadb/src/dialect.ts#L51