### PR TITLE
docs/migrations: add Atlas/Sequelize integration

### DIFF
--- a/docs/models/migrations.md
+++ b/docs/models/migrations.md
@@ -22,6 +22,8 @@ Head to [the `@sequelize/cli` page](../cli.md) for more information on how to wr
 
 Of course, you are free to use any other migration tool:
 
+- [Atlas](https://github.com/ariga/atlas) provides built-in integration for Sequelize, including automatic migration planning, migration linting, schema diffing, and more.
+  Read more in [Atlas/Sequelize portal](https://atlasgo.io/guides/orms/sequelize).
 - [Umzug](https://github.com/sequelize/umzug) is a great alternative that the Sequelize CLI uses under the hood.
 - Third-party tools that can be used to help with migrations are also listed on the [Third-Party Resources](../other-topics/resources.md#migrations) page.
 


### PR DESCRIPTION
Hey team,

Atlas is a Schema-as-Code and migration tool that supports most ORMs. A few months ago, we added support for Sequelize after it was requested many times by our community. In short, what Atlas provides for Sequelize' users is:
- Automatic migration planning: It can read the Sequelize models from either JS/TS definitions and maintains for the users the migrations directory. Your can see the provider on GitHub: [ariga/atlas-provider-sequelize](https://github.com/ariga/atlas-provider-sequelize)
- Schema diff: Atlas can compare Sequelize schema to databases, other Sequelize projects or other ORMs. 
- Allow extending the Sequelize schema with additional non ORM-ish objects such as triggers, RLS, functions, etc.
- Migration linting, testing, and [more](https://atlasgo.io/guides/orms/sequelize).

For other example integrations we did:
- Prisma: https://www.prisma.io/blog/advanced-database-schema-management-with-atlas-and-prisma-orm
- GORM: https://gorm.io/docs/migration.html#Atlas-Integration
- Ent: https://entgo.io/docs/versioned-migrations
- [Beego](https://github.com/beego/beedoc/blob/master/en-US/mvc/model/migrations.md?plain=1#L82), and more here: https://atlasgo.io/orms