### PR TITLE
document changes to sql functions

### DIFF
--- a/docs/querying/raw-queries.mdx
+++ b/docs/querying/raw-queries.mdx
@@ -37,7 +37,7 @@ const users = await User.findAll({
 
 In the above example, we used a variable in our raw SQL. Thanks to the `sql` tag, Sequelize will automatically escape that variable to remove any risk of SQL injection.
 
-Sequelize supports two different ways to pass variables in raw SQL: **Replacements** and **Bind Parameters**.
+Sequelize supports two different ways to pass variables in raw SQL: **Replacements** and **Bind Parameters**.  
 Replacements and bind parameters are available in all querying methods, and can be used together in the same query.
 
 ### Replacements
@@ -136,7 +136,7 @@ await Project.findAll({
 });
 ```
 
-Sequelize does not currently support a way to [specify the DataType of a bind parameter](https://github.com/sequelize/sequelize/issues/14410).
+Sequelize does not currently support a way to [specify the DataType of a bind parameter](https://github.com/sequelize/sequelize/issues/14410).  
 Until such a feature is implemented, you can cast your bind parameters if you need to change their DataType:
 
 ```js

--- a/docs/querying/raw-queries.mdx
+++ b/docs/querying/raw-queries.mdx
@@ -37,7 +37,7 @@ const users = await User.findAll({
 
 In the above example, we used a variable in our raw SQL. Thanks to the `sql` tag, Sequelize will automatically escape that variable to remove any risk of SQL injection.
 
-Sequelize supports two different ways to pass variables in raw SQL: **Replacements** and **Bind Parameters**.  
+Sequelize supports two different ways to pass variables in raw SQL: **Replacements** and **Bind Parameters**.
 Replacements and bind parameters are available in all querying methods, and can be used together in the same query.
 
 ### Replacements
@@ -136,7 +136,7 @@ await Project.findAll({
 });
 ```
 
-Sequelize does not currently support a way to [specify the DataType of a bind parameter](https://github.com/sequelize/sequelize/issues/14410).  
+Sequelize does not currently support a way to [specify the DataType of a bind parameter](https://github.com/sequelize/sequelize/issues/14410).
 Until such a feature is implemented, you can cast your bind parameters if you need to change their DataType:
 
 ```js
@@ -333,6 +333,7 @@ await sequelize.query(sql`SELECT ${sql.join(columns, ', ')} FROM projects`);
 ```
 
 ```sql
+-- The identifier quotes are dialect-specific, this is an example for PostgreSQL
 SELECT "name", "funding" FROM projects
 ```
 
@@ -354,6 +355,10 @@ The separator can also be any SQL fragment:
 const values = ['active', 'pending'];
 
 await sequelize.query(sql`SELECT * FROM projects WHERE status IN ${sql.join(values, sql`, `)}`);
+```
+
+```sql
+SELECT * FROM projects WHERE status IN ('active', 'pending')
 ```
 
 ### `sql.where`

--- a/docs/querying/raw-queries.mdx
+++ b/docs/querying/raw-queries.mdx
@@ -37,7 +37,7 @@ const users = await User.findAll({
 
 In the above example, we used a variable in our raw SQL. Thanks to the `sql` tag, Sequelize will automatically escape that variable to remove any risk of SQL injection.
 
-Sequelize supports two different ways to pass variables in raw SQL: **Replacements** and **Bind Parameters**.  
+Sequelize supports two different ways to pass variables in raw SQL: **Replacements** and **Bind Parameters**.
 Replacements and bind parameters are available in all querying methods, and can be used together in the same query.
 
 ### Replacements
@@ -60,7 +60,7 @@ The `replacements` option must contain all bound values, or Sequelize will throw
 ```js
 import { QueryTypes } from '@sequelize/core';
 
-// This query use positional replacements
+// This query uses positional replacements
 await sequelize.query('SELECT * FROM projects WHERE status = ?', {
   replacements: ['active'],
 });
@@ -136,7 +136,7 @@ await Project.findAll({
 });
 ```
 
-Sequelize does not currently support a way to [specify the DataType of a bind parameter](https://github.com/sequelize/sequelize/issues/14410).  
+Sequelize does not currently support a way to [specify the DataType of a bind parameter](https://github.com/sequelize/sequelize/issues/14410).
 Until such a feature is implemented, you can cast your bind parameters if you need to change their DataType:
 
 ```js
@@ -259,6 +259,34 @@ await sequelize.query(sql`SELECT * FROM ${sql.identifier('projects')}`);
 SELECT * FROM "projects"
 ```
 
+You can specify more than one identifier:
+
+```js
+import { sql } from '@sequelize/core';
+
+await sequelize.query(sql`SELECT * FROM ${sql.identifier('public', 'users')}`);
+```
+
+```sql
+-- The identifier quotes are dialect-specific, this is an example for PostgreSQL
+SELECT * FROM "public"."users"
+```
+
+Using a Model class as an identifier will automatically use the table name of the Model:
+
+```js
+import { User, sql } from '@sequelize/core';
+
+class User extends Model {}
+
+await sequelize.query(sql`SELECT * FROM ${sql.identifier(User)}`);
+```
+
+```sql
+-- The identifier quotes are dialect-specific, this is an example for PostgreSQL
+SELECT * FROM "users"
+```
+
 ### `sql.list`
 
 When using an array as a variable in a query, Sequelize will by default treat it as an SQL array:
@@ -292,6 +320,41 @@ When using `sql.list` make sure that the array contains at least one value, othe
 Read more about this in [#15142](https://github.com/sequelize/sequelize/issues/15142)
 
 :::
+
+### `sql.join`
+
+The `sql.join` function can be used to join multiple SQL fragments together.
+It is designed to be the equivalent of [`Array.prototype.join`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join) for SQL fragments.
+
+```ts
+const columns = [sql.identifier('name'), sql.identifier('funding')];
+
+await sequelize.query(sql`SELECT ${sql.join(columns, ', ')} FROM projects`);
+```
+
+```sql
+SELECT "name", "funding" FROM projects
+```
+
+Like with the `sql` tag, all non-sql values in the array passed to `sql.join` will be escaped:
+
+```ts
+const values = ['active', 'pending'];
+
+await sequelize.query(sql`SELECT * FROM projects WHERE status IN (${sql.join(values, ', ')})`);
+```
+
+```sql
+SELECT * FROM projects WHERE status IN ('active', 'pending')
+```
+
+The separator can also be any SQL fragment:
+
+```ts
+const values = ['active', 'pending'];
+
+await sequelize.query(sql`SELECT * FROM projects WHERE status IN ${sql.join(values, sql`, `)}`);
+```
 
 ### `sql.where`
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,5 @@
   "lint-staged": {
     "*.{js,mjs,cjs,ts,mts,cts}": "eslint --fix --report-unused-disable-directives",
     "*": "prettier --write --ignore-unknown"
-  },
-  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -70,5 +70,6 @@
   "lint-staged": {
     "*.{js,mjs,cjs,ts,mts,cts}": "eslint --fix --report-unused-disable-directives",
     "*": "prettier --write --ignore-unknown"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,15 +4281,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001578, caniuse-lite@^1.0.30001580:
-  version "1.0.30001585"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001585.tgz#0b4e848d84919c783b2a41c13f7de8ce96744401"
-  integrity sha512-yr2BWR1yLXQ8fMpdS/4ZZXpseBgE7o4g41x3a6AJOqZuOi+iE/WdJYAuZ6Y95i4Ohd2Y+9MzIWRR+uGABH4s3Q==
-
-caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669:
-  version "1.0.30001679"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001679.tgz#18c573b72f72ba70822194f6c39e7888597f9e32"
-  integrity sha512-j2YqID/YwpLnKzCmBOS4tlZdWprXm3ZmQLBH9ZBXFOhoxLA46fwyBvx6toCBWBmnuwUY/qB3kEU6gFx8qgCroA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001578, caniuse-lite@^1.0.30001580, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669:
+  version "1.0.30001702"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz"
+  integrity sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==
 
 ccount@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This PR documents:

- changes to `sql.identifier`
- the new `sql.join` function

Related PR: https://github.com/sequelize/sequelize/pull/17744