### PR TITLE
Fix code in `validations-and-constraints.md`

### DIFF
--- a/versioned_docs/version-6.x.x/core-concepts/validations-and-constraints.md
+++ b/versioned_docs/version-6.x.x/core-concepts/validations-and-constraints.md
@@ -194,11 +194,12 @@ You also can conditionally allow `null` values, with a custom validator, since i
 class User extends Model {}
 User.init(
   {
-    age: Sequelize.INTEGER,
+    age: DataTypes.INTEGER,
     name: {
       type: DataTypes.STRING,
       allowNull: true,
       validate: {
+        /** @this {User} */
         customValidator(value) {
           if (value === null && this.age !== 10) {
             throw new Error("name can't be null unless age is 10");
@@ -245,8 +246,8 @@ An example:
 class Place extends Model {}
 Place.init(
   {
-    name: Sequelize.STRING,
-    address: Sequelize.STRING,
+    name: DataTypes.STRING,
+    address: DataTypes.STRING,
     latitude: {
       type: DataTypes.INTEGER,
       validate: {
@@ -265,6 +266,7 @@ Place.init(
   {
     sequelize,
     validate: {
+      /** @this {Place} */
       bothCoordsOrNone() {
         if ((this.latitude === null) !== (this.longitude === null)) {
           throw new Error('Either both latitude and longitude, or neither!');


### PR DESCRIPTION
Two kinds of errors here:

1. `Sequelize.STRING` and `Sequelize.INTEGER` don't exist. These should be `DataTypes.STRING` and `DataTypes.INTEGER` instead.
2. TypeScript assumes that `this` corresponds to the `ModelValidateOptions` that the validation method is defined in.

In a TypeScript file, we would write

```ts
User.init({
  ...,
  validate: {
    customValidator(this: User, value: string | null) {
      // ...
    }
  }
```

But your examples are in JS, so I'm writing a JSDoc equivalent. While I wouldn't usually force types upon people who choose to write untyped code, this is a special case. Without this, the people who *do* choose to use types will otherwise see the *wrong* type here.