### PR TITLE
fix incorrect example of attributes array in query options

### DIFF
--- a/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
+++ b/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
@@ -69,7 +69,7 @@ Attributes can be renamed using a nested array:
 
 ```js
 Model.findAll({
-  attributes: ['foo', ['bar', 'baz'], 'qux'],
+  attributes: [['foo', 'baz'], ['baz', 'qux']],
 });
 ```
 
@@ -81,7 +81,7 @@ You can use [`sequelize.fn`](pathname:///api/v6/class/src/sequelize.js~Sequelize
 
 ```js
 Model.findAll({
-  attributes: ['foo', [sequelize.fn('COUNT', sequelize.col('hats')), 'n_hats'], 'bar'],
+  attributes: [['foo', 'bar'], [sequelize.fn('COUNT', sequelize.col('hats')), 'n_hats']],
 });
 ```
 


### PR DESCRIPTION
Under the heading "Specifying attributes for SELECT queries" on the "Model Querying - Basics" documentation page, the previous example for mapping field names to aliases incorrectly showed:

Model.findAll({
  attributes: ['foo', ['bar', 'baz'], 'qux'],
});

This syntax is invalid and would result in a runtime error. It has been updated to the correct format for the attributes option:

    attributes: [['foo', 'baz'], ['baz', 'qux']]

which correctly maps the field names to aliases.

Additionally, the same syntax error appears in the next example under the same heading:

Model.findAll({
  attributes: [['foo', 'bar'], [sequelize.fn('COUNT', sequelize.col('hats')), 'n_hats']],
});

updated it to use the right syntax for the attributes option:
    attributes: [['foo', 'bar'], [sequelize.fn('COUNT', sequelize.col('hats')), 'n_hats']]