### PR TITLE
docs: fix incorrect example of attributes in SELECT query docs docs

### DIFF
--- a/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
+++ b/versioned_docs/version-6.x.x/core-concepts/model-querying-basics.md
@@ -69,7 +69,10 @@ Attributes can be renamed using a nested array:
 
 ```js
 Model.findAll({
-  attributes: ['foo', ['bar', 'baz'], 'qux'],
+  attributes: [
+    ['foo', 'baz'],
+    ['baz', 'qux'],
+  ],
 });
 ```
 
@@ -81,7 +84,10 @@ You can use [`sequelize.fn`](pathname:///api/v6/class/src/sequelize.js~Sequelize
 
 ```js
 Model.findAll({
-  attributes: ['foo', [sequelize.fn('COUNT', sequelize.col('hats')), 'n_hats'], 'bar'],
+  attributes: [
+    ['foo', 'bar'],
+    [sequelize.fn('COUNT', sequelize.col('hats')), 'n_hats'],
+  ],
 });
 ```
 


### PR DESCRIPTION
Under the heading "Specifying attributes for SELECT queries" in the
"Model Querying - Basics" documentation page, the example incorrectly
used:
```js
Model.findAll({
  attributes: ['foo', ['bar', 'baz'], 'qux'],
});
```
which would cause a runtime error. Updated it to the correct format:
```js
Model.findAll({
  attributes: [['foo', 'baz'], ['baz', 'qux']],
});
```
to properly map field names to aliases.

Also fixed a similar issue in the next example on the same page, which used the same incorrect structure for the attributes option, the previous example showed:
```js
Model.findAll({
  attributes: ['foo', [sequelize.fn('COUNT', sequelize.col('hats')), 'n_hats'], 'bar'],
});
```
which causes a the same runtime error. Updated it to the right format:
```js
Model.findAll({
  attributes: [['foo', 'bar'], [sequelize.fn('COUNT', sequelize.col('hats')), 'n_hats']],
});
```
These correction ensures valid syntax and clearer guidance for Sequelize users.