### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,7 +15,7 @@ const config = {
   organizationName: 'sequelize',
   trailingSlash: true,
   projectName: 'sequelize',
-  plugins: ['docusaurus-plugin-sass'],
+  plugins: ['docusaurus-plugin-sass', 'docusaurus-plugin-copy-page-button'],
   markdown: {
     hooks: {
       onBrokenMarkdownLinks: 'warn',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@react-hookz/web": "25.2.0",
     "@sequelize/utils": "7.0.0-alpha.48",
     "clsx": "2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.8.1",
     "docusaurus-plugin-sass": "0.2.6",
     "prism-react-renderer": "2.4.1",
     "raw-loader": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10788,6 +10788,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"docusaurus-plugin-copy-page-button@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.8.1"
+  peerDependencies:
+    "@docusaurus/core": ^3.0.0
+    react: ^18.0.0 || ^19.0.0
+  checksum: 10c0/be9a9206f2035069416d8b4d7d98adc2ecece0bee7be629becf0644b5efda65949b7ad2afdf169b9db105d26f847bbfa638204a5981a198e9f50bdeffafc8692
+  languageName: node
+  linkType: hard
+
 "docusaurus-plugin-sass@npm:0.2.6":
   version: 0.2.6
   resolution: "docusaurus-plugin-sass@npm:0.2.6"
@@ -20739,6 +20749,7 @@ __metadata:
     "@sequelize/utils": "npm:7.0.0-alpha.48"
     clsx: "npm:2.1.1"
     concurrently: "npm:9.2.1"
+    docusaurus-plugin-copy-page-button: "npm:^0.8.1"
     docusaurus-plugin-sass: "npm:0.2.6"
     eslint: "npm:9.39.4"
     eslint-plugin-jsx-a11y: "npm:6.10.2"


### PR DESCRIPTION
This PR
- adds docusaurus-plugin-copy-page-button to package.json
- adds the plugin string to plugins in docusaurus.config.js
- puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
- adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

why useful for Sequelize specifically:
model definitions, associations, migrations, and the query-interface nuances are very per-page, and the docs are versioned (v6/v7) so the right page matters. the typical flow is reading a docs page → asking an LLM to write the model or query against it. this drops the exact page in as context instead of a hand-pasted snippet. (works across the versioned docs dirs.)

zero config, auto-injects into the TOC sidebar, theme-aware.

shipping on React Native, Redux Toolkit, Puppeteer, pnpm, PlayCanvas, Arbitrum, Cardano, Sui, Nillion, Flare, Kaia, and ~20 other docs sites. listed on the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
